### PR TITLE
(#11) Implement `SpacingBetweenLines` property in `ParagraphFormat`

### DIFF
--- a/src/Common/OfficeFlow.TestFramework/Extensions/XElementAssertionsExtensions.cs
+++ b/src/Common/OfficeFlow.TestFramework/Extensions/XElementAssertionsExtensions.cs
@@ -1,0 +1,14 @@
+﻿using System.Xml.Linq;
+using FluentAssertions;
+using FluentAssertions.Xml;
+
+namespace OfficeFlow.TestFramework.Extensions;
+
+public static class XElementAssertionsExtensions
+{
+    public static AndConstraint<XElementAssertions> HaveName(this XElementAssertions assertions, XName name)
+        => assertions.Match(element => element.Name == name, because: "XElement must have a specified name: \"{0}\"", name);
+    
+    public static AndConstraint<XElementAssertions> NotHaveName(this XElementAssertions assertions, XName name)
+        => assertions.Match(element => element.Name != name, because: "XElement must not have a specified name: \"{0}\"", name);
+}

--- a/src/Word/OfficeFlow.Word.Core.Tests/ParagraphTests.cs
+++ b/src/Word/OfficeFlow.Word.Core.Tests/ParagraphTests.cs
@@ -1,6 +1,7 @@
 ﻿using System.Linq;
 using FluentAssertions;
 using OfficeFlow.Word.Core.Elements.Paragraphs;
+using OfficeFlow.Word.Core.Elements.Paragraphs.Formatting;
 using OfficeFlow.Word.Core.Elements.Paragraphs.Text;
 using Xunit;
 

--- a/src/Word/OfficeFlow.Word.Core/Elements/Paragraphs/Formatting/Enums/HorizontalAlignment.cs
+++ b/src/Word/OfficeFlow.Word.Core/Elements/Paragraphs/Formatting/Enums/HorizontalAlignment.cs
@@ -1,4 +1,4 @@
-﻿namespace OfficeFlow.Word.Core.Elements.Paragraphs.Enums;
+﻿namespace OfficeFlow.Word.Core.Elements.Paragraphs.Formatting.Enums;
 
 public enum HorizontalAlignment
 {

--- a/src/Word/OfficeFlow.Word.Core/Elements/Paragraphs/Formatting/Enums/TextAlignment.cs
+++ b/src/Word/OfficeFlow.Word.Core/Elements/Paragraphs/Formatting/Enums/TextAlignment.cs
@@ -1,4 +1,4 @@
-﻿namespace OfficeFlow.Word.Core.Elements.Paragraphs.Enums;
+﻿namespace OfficeFlow.Word.Core.Elements.Paragraphs.Formatting.Enums;
 
 public enum TextAlignment
 {

--- a/src/Word/OfficeFlow.Word.Core/Elements/Paragraphs/Formatting/ParagraphFormat.cs
+++ b/src/Word/OfficeFlow.Word.Core/Elements/Paragraphs/Formatting/ParagraphFormat.cs
@@ -1,10 +1,10 @@
 ﻿using OfficeFlow.MeasureUnits.Absolute;
-using OfficeFlow.Word.Core.Elements.Paragraphs.Enums;
-using OfficeFlow.Word.Core.Elements.Paragraphs.Spacing;
-using OfficeFlow.Word.Core.Elements.Paragraphs.Spacing.Interfaces;
+using OfficeFlow.Word.Core.Elements.Paragraphs.Formatting.Enums;
+using OfficeFlow.Word.Core.Elements.Paragraphs.Formatting.Spacing;
+using OfficeFlow.Word.Core.Elements.Paragraphs.Formatting.Spacing.Interfaces;
 using OfficeFlow.Word.Core.Interfaces;
 
-namespace OfficeFlow.Word.Core.Elements.Paragraphs;
+namespace OfficeFlow.Word.Core.Elements.Paragraphs.Formatting;
 
 public sealed class ParagraphFormat : IVisitable
 {
@@ -22,6 +22,9 @@ public sealed class ParagraphFormat : IVisitable
 
     public IParagraphSpacing SpacingAfter { get; set; } 
         = ParagraphSpacing.Exactly(8.0, AbsoluteUnits.Points);
+    
+    public ILineSpacing SpacingBetweenLines { get; set; } 
+        = LineSpacing.Multiple(factor: 1.08);
     
     public bool KeepLines { get; set; }
     

--- a/src/Word/OfficeFlow.Word.Core/Elements/Paragraphs/Formatting/Spacing/AtLeastSpacing.cs
+++ b/src/Word/OfficeFlow.Word.Core/Elements/Paragraphs/Formatting/Spacing/AtLeastSpacing.cs
@@ -1,8 +1,8 @@
 ﻿using System;
 using OfficeFlow.MeasureUnits.Absolute;
-using OfficeFlow.Word.Core.Elements.Paragraphs.Spacing.Interfaces;
+using OfficeFlow.Word.Core.Elements.Paragraphs.Formatting.Spacing.Interfaces;
 
-namespace OfficeFlow.Word.Core.Elements.Paragraphs.Spacing;
+namespace OfficeFlow.Word.Core.Elements.Paragraphs.Formatting.Spacing;
 
 public sealed class AtLeastSpacing : ILineSpacing, IEquatable<AtLeastSpacing>
 {

--- a/src/Word/OfficeFlow.Word.Core/Elements/Paragraphs/Formatting/Spacing/AutoSpacing.cs
+++ b/src/Word/OfficeFlow.Word.Core/Elements/Paragraphs/Formatting/Spacing/AutoSpacing.cs
@@ -1,0 +1,9 @@
+﻿using OfficeFlow.Word.Core.Elements.Paragraphs.Formatting.Spacing.Interfaces;
+
+namespace OfficeFlow.Word.Core.Elements.Paragraphs.Formatting.Spacing;
+
+public sealed class AutoSpacing : IParagraphSpacing
+{
+    internal AutoSpacing()
+    { }
+}

--- a/src/Word/OfficeFlow.Word.Core/Elements/Paragraphs/Formatting/Spacing/ExactSpacing.cs
+++ b/src/Word/OfficeFlow.Word.Core/Elements/Paragraphs/Formatting/Spacing/ExactSpacing.cs
@@ -1,8 +1,8 @@
 ﻿using System;
 using OfficeFlow.MeasureUnits.Absolute;
-using OfficeFlow.Word.Core.Elements.Paragraphs.Spacing.Interfaces;
+using OfficeFlow.Word.Core.Elements.Paragraphs.Formatting.Spacing.Interfaces;
 
-namespace OfficeFlow.Word.Core.Elements.Paragraphs.Spacing;
+namespace OfficeFlow.Word.Core.Elements.Paragraphs.Formatting.Spacing;
 
 public sealed class ExactSpacing : IParagraphSpacing, ILineSpacing, IEquatable<ExactSpacing>
 {

--- a/src/Word/OfficeFlow.Word.Core/Elements/Paragraphs/Formatting/Spacing/Interfaces/ILineSpacing.cs
+++ b/src/Word/OfficeFlow.Word.Core/Elements/Paragraphs/Formatting/Spacing/Interfaces/ILineSpacing.cs
@@ -1,0 +1,3 @@
+﻿namespace OfficeFlow.Word.Core.Elements.Paragraphs.Formatting.Spacing.Interfaces;
+
+public interface ILineSpacing;

--- a/src/Word/OfficeFlow.Word.Core/Elements/Paragraphs/Formatting/Spacing/Interfaces/IParagraphSpacing.cs
+++ b/src/Word/OfficeFlow.Word.Core/Elements/Paragraphs/Formatting/Spacing/Interfaces/IParagraphSpacing.cs
@@ -1,0 +1,3 @@
+﻿namespace OfficeFlow.Word.Core.Elements.Paragraphs.Formatting.Spacing.Interfaces;
+
+public interface IParagraphSpacing;

--- a/src/Word/OfficeFlow.Word.Core/Elements/Paragraphs/Formatting/Spacing/LineSpacing.cs
+++ b/src/Word/OfficeFlow.Word.Core/Elements/Paragraphs/Formatting/Spacing/LineSpacing.cs
@@ -1,10 +1,19 @@
 ﻿using OfficeFlow.MeasureUnits.Absolute;
-using OfficeFlow.Word.Core.Elements.Paragraphs.Spacing.Interfaces;
+using OfficeFlow.Word.Core.Elements.Paragraphs.Formatting.Spacing.Interfaces;
 
-namespace OfficeFlow.Word.Core.Elements.Paragraphs.Spacing;
+namespace OfficeFlow.Word.Core.Elements.Paragraphs.Formatting.Spacing;
 
 public static class LineSpacing
 {
+    public static readonly ILineSpacing Single
+        = Multiple(factor: 1.0);
+
+    public static readonly ILineSpacing OneAndHalf
+        = Multiple(factor: 1.5);
+    
+    public static readonly ILineSpacing Double
+        = Multiple(factor: 2.0);
+    
     public static ILineSpacing Exactly<TUnits>(AbsoluteValue<TUnits> value)
         where TUnits : AbsoluteUnits, new()
         => new ExactSpacing(
@@ -25,6 +34,7 @@ public static class LineSpacing
         => AtLeast(
             AbsoluteValue.From(value, units));
     
-    public static readonly ILineSpacing Auto
-        = new AutoSpacing();
+    // TODO[#11]: Design relative measurement units
+    public static ILineSpacing Multiple(double factor)
+        => new MultipleSpacing(factor);
 }

--- a/src/Word/OfficeFlow.Word.Core/Elements/Paragraphs/Formatting/Spacing/MultipleSpacing.cs
+++ b/src/Word/OfficeFlow.Word.Core/Elements/Paragraphs/Formatting/Spacing/MultipleSpacing.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using OfficeFlow.Word.Core.Elements.Paragraphs.Formatting.Spacing.Interfaces;
+
+namespace OfficeFlow.Word.Core.Elements.Paragraphs.Formatting.Spacing;
+
+public sealed class MultipleSpacing : ILineSpacing, IEquatable<MultipleSpacing>
+{
+    private const double MinValue = 0.0;
+    private const double MaxValue = 132.0;
+    
+    // TODO[#11]: Design relative measurement units
+    public double Factor { get; }
+    
+    internal MultipleSpacing(double factor)
+    {
+        if (factor is < MinValue or > MaxValue)
+            throw new ArgumentException(
+                $"The factor of multiple spacing must be between {MinValue} and {MaxValue}", 
+                nameof(factor));
+            
+        Factor = factor;
+    }
+    
+    public bool Equals(MultipleSpacing? other)
+        => other is not null && Factor.Equals(other.Factor);
+
+    /// <inheritdoc />
+    public override bool Equals(object? other)
+        => other is MultipleSpacing spacing && Equals(spacing);
+
+    /// <inheritdoc />
+    public override int GetHashCode()
+        => Factor.GetHashCode();
+}

--- a/src/Word/OfficeFlow.Word.Core/Elements/Paragraphs/Formatting/Spacing/ParagraphSpacing.cs
+++ b/src/Word/OfficeFlow.Word.Core/Elements/Paragraphs/Formatting/Spacing/ParagraphSpacing.cs
@@ -1,7 +1,7 @@
 ﻿using OfficeFlow.MeasureUnits.Absolute;
-using OfficeFlow.Word.Core.Elements.Paragraphs.Spacing.Interfaces;
+using OfficeFlow.Word.Core.Elements.Paragraphs.Formatting.Spacing.Interfaces;
 
-namespace OfficeFlow.Word.Core.Elements.Paragraphs.Spacing;
+namespace OfficeFlow.Word.Core.Elements.Paragraphs.Formatting.Spacing;
 
 public static class ParagraphSpacing
 {

--- a/src/Word/OfficeFlow.Word.Core/Elements/Paragraphs/Paragraph.cs
+++ b/src/Word/OfficeFlow.Word.Core/Elements/Paragraphs/Paragraph.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 using System.Text;
 using OfficeFlow.DocumentObjectModel;
+using OfficeFlow.Word.Core.Elements.Paragraphs.Formatting;
 using OfficeFlow.Word.Core.Elements.Paragraphs.Text;
 using OfficeFlow.Word.Core.Interfaces;
 

--- a/src/Word/OfficeFlow.Word.Core/Elements/Paragraphs/Spacing/AutoSpacing.cs
+++ b/src/Word/OfficeFlow.Word.Core/Elements/Paragraphs/Spacing/AutoSpacing.cs
@@ -1,9 +1,0 @@
-﻿using OfficeFlow.Word.Core.Elements.Paragraphs.Spacing.Interfaces;
-
-namespace OfficeFlow.Word.Core.Elements.Paragraphs.Spacing;
-
-public sealed class AutoSpacing : IParagraphSpacing, ILineSpacing
-{
-    internal AutoSpacing()
-    { }
-}

--- a/src/Word/OfficeFlow.Word.Core/Elements/Paragraphs/Spacing/Interfaces/ILineSpacing.cs
+++ b/src/Word/OfficeFlow.Word.Core/Elements/Paragraphs/Spacing/Interfaces/ILineSpacing.cs
@@ -1,3 +1,0 @@
-﻿namespace OfficeFlow.Word.Core.Elements.Paragraphs.Spacing.Interfaces;
-
-public interface ILineSpacing;

--- a/src/Word/OfficeFlow.Word.Core/Elements/Paragraphs/Spacing/Interfaces/IParagraphSpacing.cs
+++ b/src/Word/OfficeFlow.Word.Core/Elements/Paragraphs/Spacing/Interfaces/IParagraphSpacing.cs
@@ -1,3 +1,0 @@
-﻿namespace OfficeFlow.Word.Core.Elements.Paragraphs.Spacing.Interfaces;
-
-public interface IParagraphSpacing;

--- a/src/Word/OfficeFlow.Word.Core/Elements/Paragraphs/Text/Enums/LineBreakType.cs
+++ b/src/Word/OfficeFlow.Word.Core/Elements/Paragraphs/Text/Enums/LineBreakType.cs
@@ -1,8 +1,0 @@
-﻿namespace OfficeFlow.Word.Core.Elements.Paragraphs.Text.Enums;
-
-public enum LineBreakType
-{
-    Column,
-    Page,
-    TextWrapping
-}

--- a/src/Word/OfficeFlow.Word.Core/Elements/Paragraphs/Text/Enums/StrikethroughType.cs
+++ b/src/Word/OfficeFlow.Word.Core/Elements/Paragraphs/Text/Enums/StrikethroughType.cs
@@ -1,8 +1,0 @@
-namespace OfficeFlow.Word.Core.Elements.Paragraphs.Text.Enums;
-
-public enum StrikethroughType
-{
-    None,
-    Single,
-    Double
-}

--- a/src/Word/OfficeFlow.Word.Core/Elements/Paragraphs/Text/Formatting/Enums/LineBreakType.cs
+++ b/src/Word/OfficeFlow.Word.Core/Elements/Paragraphs/Text/Formatting/Enums/LineBreakType.cs
@@ -1,0 +1,8 @@
+﻿namespace OfficeFlow.Word.Core.Elements.Paragraphs.Text.Formatting.Enums;
+
+public enum LineBreakType
+{
+    Column,
+    Page,
+    TextWrapping
+}

--- a/src/Word/OfficeFlow.Word.Core/Elements/Paragraphs/Text/Formatting/Enums/StrikethroughType.cs
+++ b/src/Word/OfficeFlow.Word.Core/Elements/Paragraphs/Text/Formatting/Enums/StrikethroughType.cs
@@ -1,0 +1,8 @@
+namespace OfficeFlow.Word.Core.Elements.Paragraphs.Text.Formatting.Enums;
+
+public enum StrikethroughType
+{
+    None,
+    Single,
+    Double
+}

--- a/src/Word/OfficeFlow.Word.Core/Elements/Paragraphs/Text/Formatting/RunFormat.cs
+++ b/src/Word/OfficeFlow.Word.Core/Elements/Paragraphs/Text/Formatting/RunFormat.cs
@@ -1,7 +1,7 @@
-using OfficeFlow.Word.Core.Elements.Paragraphs.Text.Enums;
+using OfficeFlow.Word.Core.Elements.Paragraphs.Text.Formatting.Enums;
 using OfficeFlow.Word.Core.Interfaces;
 
-namespace OfficeFlow.Word.Core.Elements.Paragraphs.Text;
+namespace OfficeFlow.Word.Core.Elements.Paragraphs.Text.Formatting;
 
 public sealed class RunFormat : IVisitable
 {

--- a/src/Word/OfficeFlow.Word.Core/Elements/Paragraphs/Text/LineBreak.cs
+++ b/src/Word/OfficeFlow.Word.Core/Elements/Paragraphs/Text/LineBreak.cs
@@ -1,5 +1,5 @@
 using OfficeFlow.DocumentObjectModel;
-using OfficeFlow.Word.Core.Elements.Paragraphs.Text.Enums;
+using OfficeFlow.Word.Core.Elements.Paragraphs.Text.Formatting.Enums;
 using OfficeFlow.Word.Core.Interfaces;
 
 namespace OfficeFlow.Word.Core.Elements.Paragraphs.Text;

--- a/src/Word/OfficeFlow.Word.Core/Elements/Paragraphs/Text/Run.cs
+++ b/src/Word/OfficeFlow.Word.Core/Elements/Paragraphs/Text/Run.cs
@@ -1,6 +1,7 @@
 ﻿using System.Linq;
 using OfficeFlow.DocumentObjectModel;
-using OfficeFlow.Word.Core.Elements.Paragraphs.Text.Enums;
+using OfficeFlow.Word.Core.Elements.Paragraphs.Text.Formatting;
+using OfficeFlow.Word.Core.Elements.Paragraphs.Text.Formatting.Enums;
 using OfficeFlow.Word.Core.Interfaces;
 
 namespace OfficeFlow.Word.Core.Elements.Paragraphs.Text;

--- a/src/Word/OfficeFlow.Word.Core/Interfaces/IWordVisitor.cs
+++ b/src/Word/OfficeFlow.Word.Core/Interfaces/IWordVisitor.cs
@@ -1,6 +1,8 @@
 ﻿using OfficeFlow.Word.Core.Elements;
 using OfficeFlow.Word.Core.Elements.Paragraphs;
+using OfficeFlow.Word.Core.Elements.Paragraphs.Formatting;
 using OfficeFlow.Word.Core.Elements.Paragraphs.Text;
+using OfficeFlow.Word.Core.Elements.Paragraphs.Text.Formatting;
 
 namespace OfficeFlow.Word.Core.Interfaces;
 

--- a/src/Word/OfficeFlow.Word.OpenXml.Tests/OpenXmlElementReaderTests/LineBreakTests.cs
+++ b/src/Word/OfficeFlow.Word.OpenXml.Tests/OpenXmlElementReaderTests/LineBreakTests.cs
@@ -1,7 +1,7 @@
 ﻿using System.Xml.Linq;
 using FluentAssertions;
 using OfficeFlow.Word.Core.Elements.Paragraphs.Text;
-using OfficeFlow.Word.Core.Elements.Paragraphs.Text.Enums;
+using OfficeFlow.Word.Core.Elements.Paragraphs.Text.Formatting.Enums;
 using Xunit;
 
 namespace OfficeFlow.Word.OpenXml.Tests.OpenXmlElementReaderTests;

--- a/src/Word/OfficeFlow.Word.OpenXml.Tests/OpenXmlElementReaderTests/RunFormatTests.cs
+++ b/src/Word/OfficeFlow.Word.OpenXml.Tests/OpenXmlElementReaderTests/RunFormatTests.cs
@@ -1,7 +1,7 @@
 ﻿using System.Xml.Linq;
 using FluentAssertions;
-using OfficeFlow.Word.Core.Elements.Paragraphs.Text;
-using OfficeFlow.Word.Core.Elements.Paragraphs.Text.Enums;
+using OfficeFlow.Word.Core.Elements.Paragraphs.Text.Formatting;
+using OfficeFlow.Word.Core.Elements.Paragraphs.Text.Formatting.Enums;
 using Xunit;
 
 namespace OfficeFlow.Word.OpenXml.Tests.OpenXmlElementReaderTests;

--- a/src/Word/OfficeFlow.Word.OpenXml.Tests/OpenXmlElementWriterTests/BodyTests.cs
+++ b/src/Word/OfficeFlow.Word.OpenXml.Tests/OpenXmlElementWriterTests/BodyTests.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Xml.Linq;
 using FluentAssertions;
+using OfficeFlow.TestFramework.Extensions;
 using OfficeFlow.Word.Core.Elements;
 using OfficeFlow.Word.Core.Elements.Paragraphs;
 using Xunit;
@@ -26,31 +27,6 @@ public sealed class BodyTests
     public void Should_write_body_element_properly()
     {
         // Arrange
-        var expectedXml = new XElement(OpenXmlNamespaces.Word + "document",
-            new XElement(OpenXmlNamespaces.Word + "body",
-                new XElement(OpenXmlNamespaces.Word + "p",
-                    new XElement(OpenXmlNamespaces.Word + "pPr",
-                        new XElement(OpenXmlNamespaces.Word + "spacing",
-                            new XAttribute(OpenXmlNamespaces.Word + "before", "0"),
-                            new XAttribute(OpenXmlNamespaces.Word + "after", "160")))),
-                new XElement(OpenXmlNamespaces.Word + "p",
-                    new XElement(OpenXmlNamespaces.Word + "pPr",
-                        new XElement(OpenXmlNamespaces.Word + "spacing",
-                            new XAttribute(OpenXmlNamespaces.Word + "before", "0"),
-                            new XAttribute(OpenXmlNamespaces.Word + "after", "160")))),
-                new XElement(OpenXmlNamespaces.Word + "p",
-                    new XElement(OpenXmlNamespaces.Word + "sectPr"),
-                    new XElement(OpenXmlNamespaces.Word + "pPr",
-                        new XElement(OpenXmlNamespaces.Word + "spacing",
-                            new XAttribute(OpenXmlNamespaces.Word + "before", "0"),
-                            new XAttribute(OpenXmlNamespaces.Word + "after", "160")))),
-                new XElement(OpenXmlNamespaces.Word + "p",
-                    new XElement(OpenXmlNamespaces.Word + "pPr",
-                        new XElement(OpenXmlNamespaces.Word + "spacing",
-                            new XAttribute(OpenXmlNamespaces.Word + "before", "0"),
-                            new XAttribute(OpenXmlNamespaces.Word + "after", "160")))),
-                new XElement(OpenXmlNamespaces.Word + "sectPr")));
-
         var sut = new OpenXmlElementWriter(
             new XElement(OpenXmlNamespaces.Word + "document"));
 
@@ -81,6 +57,19 @@ public sealed class BodyTests
         // Assert
         sut.Xml
             .Should()
-            .Be(expectedXml);
+            .HaveName(OpenXmlNamespaces.Word + "document")
+            .And
+            .HaveElement(OpenXmlNamespaces.Word + "body")
+            .Which
+            .Should()
+            .HaveElement(OpenXmlNamespaces.Word + "sectPr")
+            .And
+            .HaveElement(OpenXmlNamespaces.Word + "p", Exactly.Times(expected: 4))
+            .Which
+            .Should()
+            .AllSatisfy(paragraphXml => 
+                paragraphXml
+                    .Should()
+                    .HaveElement(OpenXmlNamespaces.Word + "pPr"));
     }
 }

--- a/src/Word/OfficeFlow.Word.OpenXml.Tests/OpenXmlElementWriterTests/LineBreakTests.cs
+++ b/src/Word/OfficeFlow.Word.OpenXml.Tests/OpenXmlElementWriterTests/LineBreakTests.cs
@@ -2,7 +2,7 @@
 using FluentAssertions;
 using OfficeFlow.TestFramework.Extensions;
 using OfficeFlow.Word.Core.Elements.Paragraphs.Text;
-using OfficeFlow.Word.Core.Elements.Paragraphs.Text.Enums;
+using OfficeFlow.Word.Core.Elements.Paragraphs.Text.Formatting.Enums;
 using Xunit;
 
 namespace OfficeFlow.Word.OpenXml.Tests.OpenXmlElementWriterTests;

--- a/src/Word/OfficeFlow.Word.OpenXml.Tests/OpenXmlElementWriterTests/LineBreakTests.cs
+++ b/src/Word/OfficeFlow.Word.OpenXml.Tests/OpenXmlElementWriterTests/LineBreakTests.cs
@@ -1,5 +1,6 @@
 ﻿using System.Xml.Linq;
 using FluentAssertions;
+using OfficeFlow.TestFramework.Extensions;
 using OfficeFlow.Word.Core.Elements.Paragraphs.Text;
 using OfficeFlow.Word.Core.Elements.Paragraphs.Text.Enums;
 using Xunit;
@@ -14,9 +15,6 @@ public sealed class LineBreakTests
     public void Should_write_line_break_type_properly(string expectedType, LineBreakType actualType)
     {
         // Assert
-        var expectedXml = new XElement(OpenXmlNamespaces.Word + "br",
-            new XAttribute(OpenXmlNamespaces.Word + "type", expectedType));
-        
         var sut = new OpenXmlElementWriter(
             new XElement(OpenXmlNamespaces.Word + "br"));
 
@@ -31,15 +29,15 @@ public sealed class LineBreakTests
         // Assert
         sut.Xml
             .Should()
-            .Be(expectedXml);
+            .HaveName(OpenXmlNamespaces.Word + "br")
+            .And
+            .HaveAttribute(OpenXmlNamespaces.Word + "type", expectedType);
     }
 
     [Fact]
     public void Default_value_of_break_type_should_not_be_written()
     {
         // Assert
-        var expectedXml = new XElement(OpenXmlNamespaces.Word + "br");
-        
         var sut = new OpenXmlElementWriter(
             new XElement(OpenXmlNamespaces.Word + "br"));
 
@@ -54,6 +52,11 @@ public sealed class LineBreakTests
         // Assert
         sut.Xml
             .Should()
-            .Be(expectedXml);
+            .HaveName(OpenXmlNamespaces.Word + "br")
+            .And
+            .Subject
+            .Elements()
+            .Should()
+            .BeEmpty();
     }
 }

--- a/src/Word/OfficeFlow.Word.OpenXml.Tests/OpenXmlElementWriterTests/ParagraphFormatTests.cs
+++ b/src/Word/OfficeFlow.Word.OpenXml.Tests/OpenXmlElementWriterTests/ParagraphFormatTests.cs
@@ -2,9 +2,9 @@
 using FluentAssertions;
 using OfficeFlow.MeasureUnits.Absolute;
 using OfficeFlow.TestFramework.Extensions;
-using OfficeFlow.Word.Core.Elements.Paragraphs;
-using OfficeFlow.Word.Core.Elements.Paragraphs.Enums;
-using OfficeFlow.Word.Core.Elements.Paragraphs.Spacing;
+using OfficeFlow.Word.Core.Elements.Paragraphs.Formatting;
+using OfficeFlow.Word.Core.Elements.Paragraphs.Formatting.Enums;
+using OfficeFlow.Word.Core.Elements.Paragraphs.Formatting.Spacing;
 using Xunit;
 
 namespace OfficeFlow.Word.OpenXml.Tests.OpenXmlElementWriterTests;
@@ -260,7 +260,6 @@ public sealed class ParagraphFormatTests
         // Assert
         sut.Xml
             .Should()
-            .Be(expectedXml);
             .HaveName(OpenXmlNamespaces.Word + "pPr")
             .And
             .HaveElement(OpenXmlNamespaces.Word + "spacing")
@@ -269,6 +268,90 @@ public sealed class ParagraphFormatTests
             .HaveAttribute(OpenXmlNamespaces.Word + "before", "0")
             .And
             .HaveAttribute(OpenXmlNamespaces.Word + "after", "240");
+    }
+
+    [Fact]
+    public void Should_write_exact_value_of_line_spacing_properly()
+    {
+        // Arrange
+        var sut = new OpenXmlElementWriter(
+            new XElement(OpenXmlNamespaces.Word + "pPr"));
+
+        var paragraphFormat = new ParagraphFormat
+        {
+            SpacingBetweenLines = LineSpacing.Exactly(value: 36, AbsoluteUnits.Points)
+        };
+        
+        // Act
+        sut.Visit(paragraphFormat);
+        
+        // Assert
+        sut.Xml
+            .Should()
+            .HaveName(OpenXmlNamespaces.Word + "pPr")
+            .And
+            .HaveElement(OpenXmlNamespaces.Word + "spacing")
+            .Which
+            .Should()
+            .HaveAttribute(OpenXmlNamespaces.Word + "lineRule", "exactly")
+            .And
+            .HaveAttribute(OpenXmlNamespaces.Word + "line", "720");
+    }
+    
+    [Fact]
+    public void Should_write_at_least_value_of_line_spacing_properly()
+    {
+        // Arrange
+        var sut = new OpenXmlElementWriter(
+            new XElement(OpenXmlNamespaces.Word + "pPr"));
+
+        var paragraphFormat = new ParagraphFormat
+        {
+            SpacingBetweenLines = LineSpacing.AtLeast(value: 36, AbsoluteUnits.Points)
+        };
+        
+        // Act
+        sut.Visit(paragraphFormat);
+        
+        // Assert
+        sut.Xml
+            .Should()
+            .HaveName(OpenXmlNamespaces.Word + "pPr")
+            .And
+            .HaveElement(OpenXmlNamespaces.Word + "spacing")
+            .Which
+            .Should()
+            .HaveAttribute(OpenXmlNamespaces.Word + "lineRule", "atLeast")
+            .And
+            .HaveAttribute(OpenXmlNamespaces.Word + "line", "720");
+    }
+    
+    [Fact]
+    public void Should_write_multiple_value_of_line_spacing_properly()
+    {
+        // Arrange
+        var sut = new OpenXmlElementWriter(
+            new XElement(OpenXmlNamespaces.Word + "pPr"));
+
+        var paragraphFormat = new ParagraphFormat
+        {
+            SpacingBetweenLines = LineSpacing.Multiple(factor: 3.0)
+        };
+        
+        // Act
+        sut.Visit(paragraphFormat);
+        
+        // Assert
+        sut.Xml
+            .Should()
+            .HaveName(OpenXmlNamespaces.Word + "pPr")
+            .And
+            .HaveElement(OpenXmlNamespaces.Word + "spacing")
+            .Which
+            .Should()
+            .HaveAttribute(OpenXmlNamespaces.Word + "lineRule", "auto")
+            .And
+            .HaveAttribute(OpenXmlNamespaces.Word + "line", "720");
     }
 
     [Fact]

--- a/src/Word/OfficeFlow.Word.OpenXml.Tests/OpenXmlElementWriterTests/ParagraphFormatTests.cs
+++ b/src/Word/OfficeFlow.Word.OpenXml.Tests/OpenXmlElementWriterTests/ParagraphFormatTests.cs
@@ -1,6 +1,7 @@
 ﻿using System.Xml.Linq;
 using FluentAssertions;
 using OfficeFlow.MeasureUnits.Absolute;
+using OfficeFlow.TestFramework.Extensions;
 using OfficeFlow.Word.Core.Elements.Paragraphs;
 using OfficeFlow.Word.Core.Elements.Paragraphs.Enums;
 using OfficeFlow.Word.Core.Elements.Paragraphs.Spacing;
@@ -18,13 +19,6 @@ public sealed class ParagraphFormatTests
     public void Should_write_horizontal_alignment_properly(string expectedValue, HorizontalAlignment actualValue)
     {
         // Arrange
-        var expectedXml = new XElement(OpenXmlNamespaces.Word + "pPr",
-            new XElement(OpenXmlNamespaces.Word + "jc", 
-                new XAttribute(OpenXmlNamespaces.Word + "val", expectedValue)),
-            new XElement(OpenXmlNamespaces.Word + "spacing",
-                new XAttribute(OpenXmlNamespaces.Word + "before", "0"),
-                new XAttribute(OpenXmlNamespaces.Word + "after", "160")));
-
         var sut = new OpenXmlElementWriter(
             new XElement(OpenXmlNamespaces.Word + "pPr"));
 
@@ -39,18 +33,18 @@ public sealed class ParagraphFormatTests
         // Assert
         sut.Xml
             .Should()
-            .Be(expectedXml);
+            .HaveName(OpenXmlNamespaces.Word + "pPr")
+            .And
+            .HaveElement(OpenXmlNamespaces.Word + "jc")
+            .Which
+            .Should()
+            .HaveAttribute(OpenXmlNamespaces.Word + "val", expectedValue);
     }
     
     [Fact]
     public void Default_value_of_horizontal_alignment_should_not_be_written()
     {
         // Arrange
-        var expectedXml = new XElement(OpenXmlNamespaces.Word + "pPr",
-            new XElement(OpenXmlNamespaces.Word + "spacing",
-                new XAttribute(OpenXmlNamespaces.Word + "before", "0"),
-                new XAttribute(OpenXmlNamespaces.Word + "after", "160")));
-        
         var sut = new OpenXmlElementWriter(
             new XElement(OpenXmlNamespaces.Word + "pPr"));
 
@@ -65,7 +59,15 @@ public sealed class ParagraphFormatTests
         // Assert
         sut.Xml
             .Should()
-            .Be(expectedXml);
+            .HaveName(OpenXmlNamespaces.Word + "pPr")
+            .And
+            .Subject
+            .Elements()
+            .Should()
+            .AllSatisfy(elementXml => 
+                elementXml
+                    .Should()
+                    .NotHaveName(OpenXmlNamespaces.Word + "jc"));
     }
     
     [Theory]
@@ -76,13 +78,6 @@ public sealed class ParagraphFormatTests
     public void Should_write_text_alignment_properly(string expectedValue, TextAlignment actualValue)
     {
         // Arrange
-        var expectedXml = new XElement(OpenXmlNamespaces.Word + "pPr",
-            new XElement(OpenXmlNamespaces.Word + "textAlignment", 
-                new XAttribute(OpenXmlNamespaces.Word + "val", expectedValue)),
-            new XElement(OpenXmlNamespaces.Word + "spacing",
-                new XAttribute(OpenXmlNamespaces.Word + "before", "0"),
-                new XAttribute(OpenXmlNamespaces.Word + "after", "160")));
-
         var sut = new OpenXmlElementWriter(
             new XElement(OpenXmlNamespaces.Word + "pPr"));
 
@@ -97,18 +92,18 @@ public sealed class ParagraphFormatTests
         // Assert
         sut.Xml
             .Should()
-            .Be(expectedXml);
+            .HaveName(OpenXmlNamespaces.Word + "pPr")
+            .And
+            .HaveElement(OpenXmlNamespaces.Word + "textAlignment")
+            .Which
+            .Should()
+            .HaveAttribute(OpenXmlNamespaces.Word + "val", expectedValue);
     }
     
     [Fact]
     public void Default_value_of_text_alignment_should_not_be_written()
     {
         // Arrange
-        var expectedXml = new XElement(OpenXmlNamespaces.Word + "pPr",
-            new XElement(OpenXmlNamespaces.Word + "spacing",
-                new XAttribute(OpenXmlNamespaces.Word + "before", "0"),
-                new XAttribute(OpenXmlNamespaces.Word + "after", "160")));
-        
         var sut = new OpenXmlElementWriter(
             new XElement(OpenXmlNamespaces.Word + "pPr"));
 
@@ -123,18 +118,21 @@ public sealed class ParagraphFormatTests
         // Assert
         sut.Xml
             .Should()
-            .Be(expectedXml);
+            .HaveName(OpenXmlNamespaces.Word + "pPr")
+            .And
+            .Subject
+            .Elements()
+            .Should()
+            .AllSatisfy(elementXml => 
+                elementXml
+                    .Should()
+                    .NotHaveName(OpenXmlNamespaces.Word + "textAlignment"));
     }
 
     [Fact]
     public void Should_write_paragraph_spacing_properly()
     {
         // Arrange
-        var expectedXml = new XElement(OpenXmlNamespaces.Word + "pPr",
-            new XElement(OpenXmlNamespaces.Word + "spacing",
-                new XAttribute(OpenXmlNamespaces.Word + "beforeAutospacing", "true"),
-                new XAttribute(OpenXmlNamespaces.Word + "after", "240")));
-        
         var sut = new OpenXmlElementWriter(
             new XElement(OpenXmlNamespaces.Word + "pPr"));
         
@@ -150,18 +148,20 @@ public sealed class ParagraphFormatTests
         // Assert
         sut.Xml
             .Should()
-            .Be(expectedXml);
+            .HaveName(OpenXmlNamespaces.Word + "pPr")
+            .And
+            .HaveElement(OpenXmlNamespaces.Word + "spacing")
+            .Which
+            .Should()
+            .HaveAttribute(OpenXmlNamespaces.Word + "beforeAutospacing", "true")
+            .And
+            .HaveAttribute(OpenXmlNamespaces.Word + "after", "240");
     }
     
     [Fact]
     public void Spacing_before_should_be_calculated_automatically()
     {
         // Arrange
-        var expectedXml = new XElement(OpenXmlNamespaces.Word + "pPr",
-            new XElement(OpenXmlNamespaces.Word + "spacing",
-                new XAttribute(OpenXmlNamespaces.Word + "beforeAutospacing", "true"),
-                new XAttribute(OpenXmlNamespaces.Word + "after", "160")));
-        
         var sut = new OpenXmlElementWriter(
             new XElement(OpenXmlNamespaces.Word + "pPr"));
         
@@ -176,18 +176,20 @@ public sealed class ParagraphFormatTests
         // Assert
         sut.Xml
             .Should()
-            .Be(expectedXml);
+            .HaveName(OpenXmlNamespaces.Word + "pPr")
+            .And
+            .HaveElement(OpenXmlNamespaces.Word + "spacing")
+            .Which
+            .Should()
+            .HaveAttribute(OpenXmlNamespaces.Word + "beforeAutospacing", "true")
+            .And
+            .HaveAttribute(OpenXmlNamespaces.Word + "after", "160");
     }
 
     [Fact]
     public void Should_write_exact_value_of_spacing_before_properly()
     {
         // Arrange
-        var expectedXml = new XElement(OpenXmlNamespaces.Word + "pPr",
-            new XElement(OpenXmlNamespaces.Word + "spacing",
-                new XAttribute(OpenXmlNamespaces.Word + "before", "240"),
-                new XAttribute(OpenXmlNamespaces.Word + "after", "160")));
-        
         var sut = new OpenXmlElementWriter(
             new XElement(OpenXmlNamespaces.Word + "pPr"));
         
@@ -202,18 +204,20 @@ public sealed class ParagraphFormatTests
         // Assert
         sut.Xml
             .Should()
-            .Be(expectedXml);
+            .HaveName(OpenXmlNamespaces.Word + "pPr")
+            .And
+            .HaveElement(OpenXmlNamespaces.Word + "spacing")
+            .Which
+            .Should()
+            .HaveAttribute(OpenXmlNamespaces.Word + "before", "240")
+            .And
+            .HaveAttribute(OpenXmlNamespaces.Word + "after", "160");
     }
     
     [Fact]
     public void Spacing_after_should_be_calculated_automatically()
     {
         // Arrange
-        var expectedXml = new XElement(OpenXmlNamespaces.Word + "pPr",
-            new XElement(OpenXmlNamespaces.Word + "spacing",
-                new XAttribute(OpenXmlNamespaces.Word + "before", "0"),
-                new XAttribute(OpenXmlNamespaces.Word + "afterAutospacing", "true")));
-        
         var sut = new OpenXmlElementWriter(
             new XElement(OpenXmlNamespaces.Word + "pPr"));
         
@@ -228,18 +232,20 @@ public sealed class ParagraphFormatTests
         // Assert
         sut.Xml
             .Should()
-            .Be(expectedXml);
+            .HaveName(OpenXmlNamespaces.Word + "pPr")
+            .And
+            .HaveElement(OpenXmlNamespaces.Word + "spacing")
+            .Which
+            .Should()
+            .HaveAttribute(OpenXmlNamespaces.Word + "before", "0")
+            .And
+            .HaveAttribute(OpenXmlNamespaces.Word + "afterAutospacing", "true");
     }
 
     [Fact]
     public void Should_write_exact_value_of_spacing_after_properly()
     {
         // Arrange
-        var expectedXml = new XElement(OpenXmlNamespaces.Word + "pPr",
-            new XElement(OpenXmlNamespaces.Word + "spacing",
-                new XAttribute(OpenXmlNamespaces.Word + "before", "0"),
-                new XAttribute(OpenXmlNamespaces.Word + "after", "240")));
-        
         var sut = new OpenXmlElementWriter(
             new XElement(OpenXmlNamespaces.Word + "pPr"));
         
@@ -255,18 +261,20 @@ public sealed class ParagraphFormatTests
         sut.Xml
             .Should()
             .Be(expectedXml);
+            .HaveName(OpenXmlNamespaces.Word + "pPr")
+            .And
+            .HaveElement(OpenXmlNamespaces.Word + "spacing")
+            .Which
+            .Should()
+            .HaveAttribute(OpenXmlNamespaces.Word + "before", "0")
+            .And
+            .HaveAttribute(OpenXmlNamespaces.Word + "after", "240");
     }
 
     [Fact]
     public void Should_write_keep_lines_properly()
     {
         // Arrange
-        var expectedXml = new XElement(OpenXmlNamespaces.Word + "pPr",
-            new XElement(OpenXmlNamespaces.Word + "spacing",
-                new XAttribute(OpenXmlNamespaces.Word + "before", "0"),
-                new XAttribute(OpenXmlNamespaces.Word + "after", "160")),
-            new XElement(OpenXmlNamespaces.Word + "keepLines"));
-        
         var sut = new OpenXmlElementWriter(
             new XElement(OpenXmlNamespaces.Word + "pPr"));
 
@@ -281,18 +289,17 @@ public sealed class ParagraphFormatTests
         // Assert
         sut.Xml
             .Should()
-            .Be(expectedXml);
+            .HaveName(OpenXmlNamespaces.Word + "pPr")
+            .And
+            .HaveElement(OpenXmlNamespaces.Word + "spacing")
+            .And
+            .HaveElement(OpenXmlNamespaces.Word + "keepLines");
     }
 
     [Fact]
     public void Should_not_write_keep_lines()
     {
         // Arrange
-        var expectedXml = new XElement(OpenXmlNamespaces.Word + "pPr",
-            new XElement(OpenXmlNamespaces.Word + "spacing",
-                new XAttribute(OpenXmlNamespaces.Word + "before", "0"),
-                new XAttribute(OpenXmlNamespaces.Word + "after", "160")));
-        
         var sut = new OpenXmlElementWriter(
             new XElement(OpenXmlNamespaces.Word + "pPr"));
 
@@ -307,19 +314,21 @@ public sealed class ParagraphFormatTests
         // Assert
         sut.Xml
             .Should()
-            .Be(expectedXml);
+            .HaveName(OpenXmlNamespaces.Word + "pPr")
+            .And
+            .Subject
+            .Elements()
+            .Should()
+            .AllSatisfy(elementXml => 
+                elementXml
+                    .Should()
+                    .NotHaveName(OpenXmlNamespaces.Word + "keepLines"));
     }
     
     [Fact]
     public void Should_write_keep_next_properly()
     {
         // Arrange
-        var expectedXml = new XElement(OpenXmlNamespaces.Word + "pPr",
-            new XElement(OpenXmlNamespaces.Word + "spacing",
-                new XAttribute(OpenXmlNamespaces.Word + "before", "0"),
-                new XAttribute(OpenXmlNamespaces.Word + "after", "160")),
-            new XElement(OpenXmlNamespaces.Word + "keepNext"));
-        
         var sut = new OpenXmlElementWriter(
             new XElement(OpenXmlNamespaces.Word + "pPr"));
 
@@ -334,18 +343,17 @@ public sealed class ParagraphFormatTests
         // Assert
         sut.Xml
             .Should()
-            .Be(expectedXml);
+            .HaveName(OpenXmlNamespaces.Word + "pPr")
+            .And
+            .HaveElement(OpenXmlNamespaces.Word + "spacing")
+            .And
+            .HaveElement(OpenXmlNamespaces.Word + "keepNext");
     }
 
     [Fact]
     public void Should_not_write_keep_next()
     {
         // Arrange
-        var expectedXml = new XElement(OpenXmlNamespaces.Word + "pPr",
-            new XElement(OpenXmlNamespaces.Word + "spacing",
-                new XAttribute(OpenXmlNamespaces.Word + "before", "0"),
-                new XAttribute(OpenXmlNamespaces.Word + "after", "160")));
-        
         var sut = new OpenXmlElementWriter(
             new XElement(OpenXmlNamespaces.Word + "pPr"));
 
@@ -360,6 +368,14 @@ public sealed class ParagraphFormatTests
         // Assert
         sut.Xml
             .Should()
-            .Be(expectedXml);
+            .HaveName(OpenXmlNamespaces.Word + "pPr")
+            .And
+            .Subject
+            .Elements()
+            .Should()
+            .AllSatisfy(elementXml => 
+                elementXml
+                    .Should()
+                    .NotHaveName(OpenXmlNamespaces.Word + "keepNext"));
     }
 }

--- a/src/Word/OfficeFlow.Word.OpenXml.Tests/OpenXmlElementWriterTests/ParagraphTests.cs
+++ b/src/Word/OfficeFlow.Word.OpenXml.Tests/OpenXmlElementWriterTests/ParagraphTests.cs
@@ -1,5 +1,6 @@
 ﻿using System.Xml.Linq;
 using FluentAssertions;
+using OfficeFlow.TestFramework.Extensions;
 using OfficeFlow.Word.Core.Elements.Paragraphs;
 using OfficeFlow.Word.Core.Elements.Paragraphs.Text;
 using Xunit;
@@ -12,12 +13,6 @@ public sealed class ParagraphTests
     public void Should_write_paragraph_format_properly()
     {
         // Assert
-        var expectedXml = new XElement(OpenXmlNamespaces.Word + "p",
-            new XElement(OpenXmlNamespaces.Word + "pPr",
-                new XElement(OpenXmlNamespaces.Word + "spacing",
-                    new XAttribute(OpenXmlNamespaces.Word + "before", "0"),
-                    new XAttribute(OpenXmlNamespaces.Word + "after", "160"))));
-        
         var sut = new OpenXmlElementWriter(
             new XElement(OpenXmlNamespaces.Word + "p"));
 
@@ -29,23 +24,15 @@ public sealed class ParagraphTests
         // Assert
         sut.Xml
             .Should()
-            .Be(expectedXml);
+            .HaveName(OpenXmlNamespaces.Word + "p")
+            .And
+            .HaveElement(OpenXmlNamespaces.Word + "pPr");
     }
     
     [Fact]
     public void Should_write_runs_properly()
     {
         // Assert
-        var expectedXml = new XElement(OpenXmlNamespaces.Word + "p",
-            new XElement(OpenXmlNamespaces.Word + "pPr",
-                new XElement(OpenXmlNamespaces.Word + "spacing",
-                    new XAttribute(OpenXmlNamespaces.Word + "before", "0"),
-                    new XAttribute(OpenXmlNamespaces.Word + "after", "160"))),
-            new XElement(OpenXmlNamespaces.Word + "r",
-                new XElement(OpenXmlNamespaces.Word + "rPr")),
-            new XElement(OpenXmlNamespaces.Word + "r",
-                new XElement(OpenXmlNamespaces.Word + "rPr")));
-        
         var sut = new OpenXmlElementWriter(
             new XElement(OpenXmlNamespaces.Word + "p"));
 
@@ -63,6 +50,8 @@ public sealed class ParagraphTests
         // Assert
         sut.Xml
             .Should()
-            .Be(expectedXml);
+            .HaveName(OpenXmlNamespaces.Word + "p")
+            .And
+            .HaveElement(OpenXmlNamespaces.Word + "r", Exactly.Times(expected: 2));
     }
 }

--- a/src/Word/OfficeFlow.Word.OpenXml.Tests/OpenXmlElementWriterTests/RunFormatTests.cs
+++ b/src/Word/OfficeFlow.Word.OpenXml.Tests/OpenXmlElementWriterTests/RunFormatTests.cs
@@ -1,5 +1,6 @@
 ﻿using System.Xml.Linq;
 using FluentAssertions;
+using OfficeFlow.TestFramework.Extensions;
 using OfficeFlow.Word.Core.Elements.Paragraphs.Text;
 using OfficeFlow.Word.Core.Elements.Paragraphs.Text.Enums;
 using Xunit;
@@ -12,9 +13,6 @@ public sealed class RunFormatTests
     public void Should_write_italic_properly()
     {
         // Assert
-        var expectedXml = new XElement(OpenXmlNamespaces.Word + "rPr",
-            new XElement(OpenXmlNamespaces.Word + "i"));
-        
         var sut = new OpenXmlElementWriter(
             new XElement(OpenXmlNamespaces.Word + "rPr"));
 
@@ -29,15 +27,15 @@ public sealed class RunFormatTests
         // Assert
         sut.Xml
             .Should()
-            .Be(expectedXml);
+            .HaveName(OpenXmlNamespaces.Word + "rPr")
+            .And
+            .HaveElement(OpenXmlNamespaces.Word + "i");
     }
 
     [Fact]
     public void Default_value_of_italic_should_not_be_written()
     {
         // Assert
-        var expectedXml = new XElement(OpenXmlNamespaces.Word + "rPr");
-        
         var sut = new OpenXmlElementWriter(
             new XElement(OpenXmlNamespaces.Word + "rPr"));
 
@@ -52,16 +50,18 @@ public sealed class RunFormatTests
         // Assert
         sut.Xml
             .Should()
-            .Be(expectedXml);
+            .HaveName(OpenXmlNamespaces.Word + "rPr")
+            .And
+            .Subject
+            .Elements()
+            .Should()
+            .BeEmpty();
     }
     
     [Fact]
     public void Should_write_bold_properly()
     {
         // Assert
-        var expectedXml = new XElement(OpenXmlNamespaces.Word + "rPr",
-            new XElement(OpenXmlNamespaces.Word + "b"));
-        
         var sut = new OpenXmlElementWriter(
             new XElement(OpenXmlNamespaces.Word + "rPr"));
 
@@ -76,15 +76,15 @@ public sealed class RunFormatTests
         // Assert
         sut.Xml
             .Should()
-            .Be(expectedXml);
+            .HaveName(OpenXmlNamespaces.Word + "rPr")
+            .And
+            .HaveElement(OpenXmlNamespaces.Word + "b");
     }
 
     [Fact]
     public void Default_value_of_bold_should_not_be_written()
     {
         // Assert
-        var expectedXml = new XElement(OpenXmlNamespaces.Word + "rPr");
-        
         var sut = new OpenXmlElementWriter(
             new XElement(OpenXmlNamespaces.Word + "rPr"));
 
@@ -99,16 +99,18 @@ public sealed class RunFormatTests
         // Assert
         sut.Xml
             .Should()
-            .Be(expectedXml);
+            .HaveName(OpenXmlNamespaces.Word + "rPr")
+            .And
+            .Subject
+            .Elements()
+            .Should()
+            .BeEmpty();
     }
     
     [Fact]
     public void Should_write_hidden_properly()
     {
         // Assert
-        var expectedXml = new XElement(OpenXmlNamespaces.Word + "rPr",
-            new XElement(OpenXmlNamespaces.Word + "vanish"));
-        
         var sut = new OpenXmlElementWriter(
             new XElement(OpenXmlNamespaces.Word + "rPr"));
 
@@ -123,15 +125,15 @@ public sealed class RunFormatTests
         // Assert
         sut.Xml
             .Should()
-            .Be(expectedXml);
+            .HaveName(OpenXmlNamespaces.Word + "rPr")
+            .And
+            .HaveElement(OpenXmlNamespaces.Word + "vanish");
     }
 
     [Fact]
     public void Default_value_of_hidden_should_not_be_written()
     {
         // Assert
-        var expectedXml = new XElement(OpenXmlNamespaces.Word + "rPr");
-        
         var sut = new OpenXmlElementWriter(
             new XElement(OpenXmlNamespaces.Word + "rPr"));
 
@@ -146,7 +148,12 @@ public sealed class RunFormatTests
         // Assert
         sut.Xml
             .Should()
-            .Be(expectedXml);
+            .HaveName(OpenXmlNamespaces.Word + "rPr")
+            .And
+            .Subject
+            .Elements()
+            .Should()
+            .BeEmpty();
     }
 
     [Theory]
@@ -155,9 +162,6 @@ public sealed class RunFormatTests
     public void Should_write_strikethrough_type_properly(string expectedStrikethroughType, StrikethroughType actualStrikethroughType)
     {
         // Assert
-        var expectedXml = new XElement(OpenXmlNamespaces.Word + "rPr",
-            new XElement(OpenXmlNamespaces.Word + expectedStrikethroughType));
-        
         var sut = new OpenXmlElementWriter(
             new XElement(OpenXmlNamespaces.Word + "rPr"));
 
@@ -172,15 +176,15 @@ public sealed class RunFormatTests
         // Assert
         sut.Xml
             .Should()
-            .Be(expectedXml);
+            .HaveName(OpenXmlNamespaces.Word + "rPr")
+            .And
+            .HaveElement(OpenXmlNamespaces.Word + expectedStrikethroughType);
     }
     
     [Fact]
     public void Default_value_of_strikethrough_type_should_not_be_written()
     {
         // Assert
-        var expectedXml = new XElement(OpenXmlNamespaces.Word + "rPr");
-        
         var sut = new OpenXmlElementWriter(
             new XElement(OpenXmlNamespaces.Word + "rPr"));
 
@@ -195,6 +199,11 @@ public sealed class RunFormatTests
         // Assert
         sut.Xml
             .Should()
-            .Be(expectedXml);
+            .HaveName(OpenXmlNamespaces.Word + "rPr")
+            .And
+            .Subject
+            .Elements()
+            .Should()
+            .BeEmpty();
     }
 }

--- a/src/Word/OfficeFlow.Word.OpenXml.Tests/OpenXmlElementWriterTests/RunFormatTests.cs
+++ b/src/Word/OfficeFlow.Word.OpenXml.Tests/OpenXmlElementWriterTests/RunFormatTests.cs
@@ -1,8 +1,8 @@
 ﻿using System.Xml.Linq;
 using FluentAssertions;
 using OfficeFlow.TestFramework.Extensions;
-using OfficeFlow.Word.Core.Elements.Paragraphs.Text;
-using OfficeFlow.Word.Core.Elements.Paragraphs.Text.Enums;
+using OfficeFlow.Word.Core.Elements.Paragraphs.Text.Formatting;
+using OfficeFlow.Word.Core.Elements.Paragraphs.Text.Formatting.Enums;
 using Xunit;
 
 namespace OfficeFlow.Word.OpenXml.Tests.OpenXmlElementWriterTests;

--- a/src/Word/OfficeFlow.Word.OpenXml.Tests/OpenXmlElementWriterTests/RunTests.cs
+++ b/src/Word/OfficeFlow.Word.OpenXml.Tests/OpenXmlElementWriterTests/RunTests.cs
@@ -1,5 +1,6 @@
 ﻿using System.Xml.Linq;
 using FluentAssertions;
+using OfficeFlow.TestFramework.Extensions;
 using OfficeFlow.Word.Core.Elements.Paragraphs.Text;
 using Xunit;
 
@@ -11,9 +12,6 @@ public sealed class RunTests
     public void Should_write_run_format_properly()
     {
         // Assert
-        var expectedXml = new XElement(OpenXmlNamespaces.Word + "r",
-            new XElement(OpenXmlNamespaces.Word + "rPr"));
-        
         var sut = new OpenXmlElementWriter(
             new XElement(OpenXmlNamespaces.Word + "r"));
 
@@ -25,19 +23,15 @@ public sealed class RunTests
         // Assert
         sut.Xml
             .Should()
-            .Be(expectedXml);
+            .HaveName(OpenXmlNamespaces.Word + "r")
+            .And
+            .HaveElement(OpenXmlNamespaces.Word + "rPr");
     }
     
     [Fact]
     public void Should_write_line_breaks_properly()
     {
         // Assert
-        var expectedXml = new XElement(OpenXmlNamespaces.Word + "r",
-            new XElement(OpenXmlNamespaces.Word + "rPr"),
-            new XElement(OpenXmlNamespaces.Word + "br"),
-            new XElement(OpenXmlNamespaces.Word + "br"),
-            new XElement(OpenXmlNamespaces.Word + "br"));
-        
         var sut = new OpenXmlElementWriter(
             new XElement(OpenXmlNamespaces.Word + "r"));
 
@@ -58,19 +52,15 @@ public sealed class RunTests
         // Assert
         sut.Xml
             .Should()
-            .Be(expectedXml);
+            .HaveName(OpenXmlNamespaces.Word + "r")
+            .And
+            .HaveElement(OpenXmlNamespaces.Word + "br", Exactly.Times(expected: 3));
     }
     
     [Fact]
     public void Should_write_vertical_tabs_properly()
     {
         // Assert
-        var expectedXml = new XElement(OpenXmlNamespaces.Word + "r",
-            new XElement(OpenXmlNamespaces.Word + "rPr"),
-            new XElement(OpenXmlNamespaces.Word + "ptab"),
-            new XElement(OpenXmlNamespaces.Word + "ptab"),
-            new XElement(OpenXmlNamespaces.Word + "ptab"));
-        
         var sut = new OpenXmlElementWriter(
             new XElement(OpenXmlNamespaces.Word + "r"));
 
@@ -91,19 +81,15 @@ public sealed class RunTests
         // Assert
         sut.Xml
             .Should()
-            .Be(expectedXml);
+            .HaveName(OpenXmlNamespaces.Word + "r")
+            .And
+            .HaveElement(OpenXmlNamespaces.Word + "ptab", Exactly.Times(expected: 3));
     }
     
     [Fact]
     public void Should_write_horizontal_tabs_properly()
     {
         // Assert
-        var expectedXml = new XElement(OpenXmlNamespaces.Word + "r",
-            new XElement(OpenXmlNamespaces.Word + "rPr"),
-            new XElement(OpenXmlNamespaces.Word + "tab"),
-            new XElement(OpenXmlNamespaces.Word + "tab"),
-            new XElement(OpenXmlNamespaces.Word + "tab"));
-        
         var sut = new OpenXmlElementWriter(
             new XElement(OpenXmlNamespaces.Word + "r"));
 
@@ -124,19 +110,15 @@ public sealed class RunTests
         // Assert
         sut.Xml
             .Should()
-            .Be(expectedXml);
+            .HaveName(OpenXmlNamespaces.Word + "r")
+            .And
+            .HaveElement(OpenXmlNamespaces.Word + "tab", Exactly.Times(expected: 3));
     }
     
     [Fact]
     public void Should_write_text_holders_properly()
     {
         // Assert
-        var expectedXml = new XElement(OpenXmlNamespaces.Word + "r",
-            new XElement(OpenXmlNamespaces.Word + "rPr"),
-            new XElement(OpenXmlNamespaces.Word + "t"),
-            new XElement(OpenXmlNamespaces.Word + "t"),
-            new XElement(OpenXmlNamespaces.Word + "t"));
-        
         var sut = new OpenXmlElementWriter(
             new XElement(OpenXmlNamespaces.Word + "r"));
 
@@ -157,6 +139,8 @@ public sealed class RunTests
         // Assert
         sut.Xml
             .Should()
-            .Be(expectedXml);
+            .HaveName(OpenXmlNamespaces.Word + "r")
+            .And
+            .HaveElement(OpenXmlNamespaces.Word + "t", Exactly.Times(expected: 3));
     }
 }

--- a/src/Word/OfficeFlow.Word.OpenXml.Tests/OpenXmlElementWriterTests/TextHolderTests.cs
+++ b/src/Word/OfficeFlow.Word.OpenXml.Tests/OpenXmlElementWriterTests/TextHolderTests.cs
@@ -1,5 +1,6 @@
 ﻿using System.Xml.Linq;
 using FluentAssertions;
+using OfficeFlow.TestFramework.Extensions;
 using OfficeFlow.Word.Core.Elements.Paragraphs.Text;
 using Xunit;
 
@@ -11,8 +12,6 @@ public sealed class TextHolderTests
     public void Should_write_text_properly()
     {
         // Assert
-        var expectedXml = new XElement(OpenXmlNamespaces.Word + "t", "Text");
-        
         var sut = new OpenXmlElementWriter(
             new XElement(OpenXmlNamespaces.Word + "t"));
 
@@ -24,7 +23,9 @@ public sealed class TextHolderTests
         // Assert
         sut.Xml
             .Should()
-            .Be(expectedXml);
+            .HaveName(OpenXmlNamespaces.Word + "t")
+            .And
+            .HaveValue("Text");
     }
 
     
@@ -35,17 +36,13 @@ public sealed class TextHolderTests
     [InlineData("Text    ")]
     [InlineData("Te xt")]
     [InlineData("Te     xt")]
-    public void Should_preserve_spaces(string text)
+    public void Should_preserve_spaces(string expectedText)
     {
         // Assert
-        var expectedXml = new XElement(OpenXmlNamespaces.Word + "t",
-            new XAttribute(XNamespace.Xml + "space", "preserve"),
-            text);
-        
         var sut = new OpenXmlElementWriter(
             new XElement(OpenXmlNamespaces.Word + "t"));
 
-        var textHolder = new TextHolder(text);
+        var textHolder = new TextHolder(expectedText);
         
         // Act
         sut.Visit(textHolder);
@@ -53,21 +50,23 @@ public sealed class TextHolderTests
         // Assert
         sut.Xml
             .Should()
-            .Be(expectedXml);
+            .HaveName(OpenXmlNamespaces.Word + "t")
+            .And
+            .HaveAttribute(XNamespace.Xml + "space", "preserve")
+            .And
+            .HaveValue(expectedText);
     }
 
     [Theory]
     [InlineData(null)]
     [InlineData("")]
-    public void Should_not_write_when_value_is_empty_or_null(string? text)
+    public void Should_not_write_when_value_is_empty_or_null(string? expectedText)
     {
         // Assert
-        var expectedXml = new XElement(OpenXmlNamespaces.Word + "t");
-        
         var sut = new OpenXmlElementWriter(
             new XElement(OpenXmlNamespaces.Word + "t"));
 
-        var textHolder = new TextHolder(text!);
+        var textHolder = new TextHolder(expectedText!);
         
         // Act
         sut.Visit(textHolder);
@@ -75,6 +74,16 @@ public sealed class TextHolderTests
         // Assert
         sut.Xml
             .Should()
-            .Be(expectedXml);
+            .HaveName(OpenXmlNamespaces.Word + "t")
+            .And
+            .Subject
+            .Elements()
+            .Should()
+            .BeEmpty()
+            .And
+            .Subject
+            .Attributes()
+            .Should()
+            .BeEmpty();
     }
 }


### PR DESCRIPTION
**Should close #11** 

**Changed:**
- The `OpenXmlElementWriterTests` now use the [FluentAssertions.Xml][links.fluent-assertions] package to assert the expected XML

**Added:**
- Added `SpacingBetweenLines` property to `ParagraphFormat`

[links.fluent-assertions]: https://github.com/fluentassertions/fluentassertions/tree/develop/Src/FluentAssertions/Xml